### PR TITLE
Fix stackql-deploy info command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,21 @@ Additional options include:
 
 Use `stackql-deploy info` to show information about the package and environment, for example:
 
-```
+```bash
 $ stackql-deploy info
-stackql-deploy version: 1.0.0
-pystackql version     : 3.5.4
-stackql version       : v0.5.612
-stackql binary path   : /mnt/c/LocalGitRepos/stackql/stackql-deploy/stackql
-platform              : Linux x86_64 (Linux-5.15.133.1-microsoft-standard-WSL2-x86_64-with-glibc2.35), Python 3.10.12
+stackql-deploy CLI
+  Version: 1.7.7
+
+StackQL Library
+  Version: v0.5.748
+  pystackql Version: 3.7.0
+  Platform: Linux x86_64 (Linux-5.15.133.1-microsoft-standard-WSL2-x86_64-with-glibc2.35), Python 3.10.12
+  Binary Path: `/mnt/c/LocalGitRepos/stackql/stackql-deploy/stackql`
+
+Installed Providers
+  aws: v24.07.00246
+  azure: v23.03.00121
+  google: v24.09.00251
 ```
 
 Use the `--help` option to see more information about the commands and options available:


### PR DESCRIPTION
## Description
I Refactored the `info` command to enhance output readability and organization ([PR](https://github.com/stackql/stackql-deploy/pull/35))
But I didn't fix the README file, So I fixed `stackql-deploy info` command in README

Fixes #

## Checklist

Please make sure that the following criteria are met:

- [x] The PR title is descriptive.
- [x] For example stacks, I have included a descriptive `README.md` in the example project directory, which describes the stack and includes instructions to deploy or test.
- [x] For example stacks, add your stack to the website template library at `website/docs/template-library/..` which gets published to [stackql-deploy.io](https://stackql-deploy.io/docs/template-library) (optional)
- [x] I have ⭐'ed the [stackql](https://github.com/stackql/stackql) and [stackql-deploy](https://github.com/stackql/stackql-deploy) repos.

## Additional Notes

![image](https://github.com/user-attachments/assets/ea8d35ae-091c-412a-a5d0-cea7d165816b)

