### PR TITLE
feat: add tab completion support for CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,44 @@ Use the `--help` option to see more information about the commands and options a
 stackql-deploy --help
 ```
 
+### Tab Completion
+
+**stackql-deploy** supports tab completion for commands and options across multiple shells. To enable tab completion:
+
+#### Bash
+Add the following to your `~/.bashrc`:
+```bash
+eval "$(_STACKQL_DEPLOY_COMPLETE=bash_source stackql-deploy)"
+```
+
+#### Zsh  
+Add the following to your `~/.zshrc`:
+```bash
+eval "$(_STACKQL_DEPLOY_COMPLETE=zsh_source stackql-deploy)"
+```
+
+#### Fish
+Add the following to your `~/.config/fish/config.fish`:
+```bash
+eval (env _STACKQL_DEPLOY_COMPLETE=fish_source stackql-deploy)
+```
+
+#### PowerShell
+Add the following to your PowerShell profile:
+```powershell
+Invoke-Expression (& stackql-deploy completion powershell)
+```
+
+> **Note:** After adding the completion configuration to your shell's configuration file, restart your terminal or source the configuration file for the changes to take effect.
+
+You can also generate shell-specific completion scripts using:
+```bash
+stackql-deploy completion bash   # for bash
+stackql-deploy completion zsh    # for zsh  
+stackql-deploy completion fish   # for fish
+stackql-deploy completion powershell  # for PowerShell
+```
+
 ## Building and Testing Locally
 
 To get started with **stackql-deploy**, install it locally using pip:

--- a/stackql_deploy/cli.py
+++ b/stackql_deploy/cli.py
@@ -386,7 +386,10 @@ def upgrade(ctx):
 #
 
 @cli.command()
-@click.argument('shell', type=click.Choice(['bash', 'zsh', 'fish', 'powershell'], case_sensitive=False))
+@click.argument(
+    'shell', 
+    type=click.Choice(['bash', 'zsh', 'fish', 'powershell'], case_sensitive=False)
+)
 def completion(shell):
     """Generate shell completion script for the specified shell.
     

--- a/stackql_deploy/cli.py
+++ b/stackql_deploy/cli.py
@@ -387,28 +387,23 @@ def upgrade(ctx):
 
 @cli.command()
 @click.argument(
-    'shell', 
+    'shell',
     type=click.Choice(['bash', 'zsh', 'fish', 'powershell'], case_sensitive=False)
 )
 def completion(shell):
     """Generate shell completion script for the specified shell.
-    
     To enable tab completion, run one of the following:
-    
     For bash (add to ~/.bashrc):
         eval "$(_STACKQL_DEPLOY_COMPLETE=bash_source stackql-deploy)"
-        
     For zsh (add to ~/.zshrc):
         eval "$(_STACKQL_DEPLOY_COMPLETE=zsh_source stackql-deploy)"
-        
     For fish (add to ~/.config/fish/config.fish):
         eval (env _STACKQL_DEPLOY_COMPLETE=fish_source stackql-deploy)
-        
     For PowerShell (add to $PROFILE):
         Invoke-Expression (& stackql-deploy completion powershell)
     """
     shell_lower = shell.lower()
-    
+
     if shell_lower == 'bash':
         click.echo('eval "$(_STACKQL_DEPLOY_COMPLETE=bash_source stackql-deploy)"')
     elif shell_lower == 'zsh':

--- a/stackql_deploy/cli.py
+++ b/stackql_deploy/cli.py
@@ -382,6 +382,49 @@ def upgrade(ctx):
 
 
 #
+# completion command
+#
+
+@cli.command()
+@click.argument('shell', type=click.Choice(['bash', 'zsh', 'fish', 'powershell'], case_sensitive=False))
+def completion(shell):
+    """Generate shell completion script for the specified shell.
+    
+    To enable tab completion, run one of the following:
+    
+    For bash (add to ~/.bashrc):
+        eval "$(_STACKQL_DEPLOY_COMPLETE=bash_source stackql-deploy)"
+        
+    For zsh (add to ~/.zshrc):
+        eval "$(_STACKQL_DEPLOY_COMPLETE=zsh_source stackql-deploy)"
+        
+    For fish (add to ~/.config/fish/config.fish):
+        eval (env _STACKQL_DEPLOY_COMPLETE=fish_source stackql-deploy)
+        
+    For PowerShell (add to $PROFILE):
+        Invoke-Expression (& stackql-deploy completion powershell)
+    """
+    shell_lower = shell.lower()
+    
+    if shell_lower == 'bash':
+        click.echo('eval "$(_STACKQL_DEPLOY_COMPLETE=bash_source stackql-deploy)"')
+    elif shell_lower == 'zsh':
+        click.echo('eval "$(_STACKQL_DEPLOY_COMPLETE=zsh_source stackql-deploy)"')
+    elif shell_lower == 'fish':
+        click.echo('eval (env _STACKQL_DEPLOY_COMPLETE=fish_source stackql-deploy)')
+    elif shell_lower == 'powershell':
+        click.echo('Register-ArgumentCompleter -Native -CommandName stackql-deploy -ScriptBlock {')
+        click.echo('    param($wordToComplete, $commandAst, $cursorPosition)')
+        click.echo('    $env:_STACKQL_DEPLOY_COMPLETE = "complete"')
+        click.echo('    $env:COMP_WORDS = $commandAst.ToString()')
+        click.echo('    $env:COMP_CWORD = $cursorPosition')
+        click.echo('    stackql-deploy | ForEach-Object {')
+        click.echo('        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)')
+        click.echo('    }')
+        click.echo('}')
+
+
+#
 # init command
 #
 SUPPORTED_PROVIDERS = {'aws', 'google', 'azure'}
@@ -458,6 +501,7 @@ cli.add_command(info)
 cli.add_command(init)
 cli.add_command(upgrade)
 cli.add_command(shell)
+cli.add_command(completion)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
This PR implements tab completion functionality for the stackql-deploy CLI as requested in issue #65.

## Changes
- Added new `completion` command to generate shell completion scripts
- Support for bash, zsh, fish, and PowerShell shells
- Leverages Click's built-in shell completion functionality
- Updated README with detailed setup instructions
- Enables tab completion for all subcommands and flags

## Usage
Users can enable tab completion by:
1. Running `stackql-deploy completion <shell>` to get setup instructions
2. Adding the appropriate line to their shell config file
3. Restarting their terminal or sourcing the config

Resolves #65

🤖 Generated with [Claude Code](https://claude.ai/code)